### PR TITLE
fixed bug from merge conflict

### DIFF
--- a/SalamanderBank/EmailService.cs
+++ b/SalamanderBank/EmailService.cs
@@ -5,6 +5,7 @@ namespace SalamanderBank;
 
 public static class EmailService
 {
+    public static Guid Code;
     private static void SendEmail(string name, string targetEmail, string subject, string message)
     {
         try


### PR DESCRIPTION
Added back the static Guid attribute after mistakenly removing it while resolving a merge conflict. 